### PR TITLE
fix(audit-log): space left values should be digits

### DIFF
--- a/roles/cis_security/defaults/main.yml
+++ b/roles/cis_security/defaults/main.yml
@@ -55,7 +55,7 @@ log_port: 514 # Linux: Port to listen to RSYSLOG messages on (if log_host is tru
 auditd_max_log_file_size: 8 # Linux: log file size. RHEL default is 8MB, control has no default
 auditd_num_logs: 5 # Linux: number of logs to keep. RHEL default is 5, control has no default
 auditd_max_log_file_action: keep_logs # Linux: action to take when auditd log file is full. RHEL default is keep_logs
-auditd_space_left_disk_size: 10000
+auditd_space_left_disk_size: 1000 # Default 1GB
 auditd_space_left_action: syslog # Linux: RHEL default is syslog
 auditd_admin_left_disk_size: 500 # Defautl to 500 MB
 auditd_admin_space_left_action: rotate # Linux: RHEL default is rotate

--- a/roles/cis_security/defaults/main.yml
+++ b/roles/cis_security/defaults/main.yml
@@ -55,9 +55,9 @@ log_port: 514 # Linux: Port to listen to RSYSLOG messages on (if log_host is tru
 auditd_max_log_file_size: 8 # Linux: log file size. RHEL default is 8MB, control has no default
 auditd_num_logs: 5 # Linux: number of logs to keep. RHEL default is 5, control has no default
 auditd_max_log_file_action: keep_logs # Linux: action to take when auditd log file is full. RHEL default is keep_logs
-auditd_space_left_disk_size: "75%" # Linux: RHEL default is 75%
+auditd_space_left_disk_size: 10000
 auditd_space_left_action: syslog # Linux: RHEL default is syslog
-auditd_admin_left_disk_size: "50%" # Linux: RHEL default is 50%
+auditd_admin_left_disk_size: 5000
 auditd_admin_space_left_action: rotate # Linux: RHEL default is rotate
 auditd_action_mail_acct: root # Linux: RHEL default is root
 

--- a/roles/cis_security/defaults/main.yml
+++ b/roles/cis_security/defaults/main.yml
@@ -57,7 +57,7 @@ auditd_num_logs: 5 # Linux: number of logs to keep. RHEL default is 5, control h
 auditd_max_log_file_action: keep_logs # Linux: action to take when auditd log file is full. RHEL default is keep_logs
 auditd_space_left_disk_size: 10000
 auditd_space_left_action: syslog # Linux: RHEL default is syslog
-auditd_admin_left_disk_size: 5000 # Defautl to 5GB
+auditd_admin_left_disk_size: 500 # Defautl to 500 MB
 auditd_admin_space_left_action: rotate # Linux: RHEL default is rotate
 auditd_action_mail_acct: root # Linux: RHEL default is root
 

--- a/roles/cis_security/defaults/main.yml
+++ b/roles/cis_security/defaults/main.yml
@@ -57,7 +57,7 @@ auditd_num_logs: 5 # Linux: number of logs to keep. RHEL default is 5, control h
 auditd_max_log_file_action: keep_logs # Linux: action to take when auditd log file is full. RHEL default is keep_logs
 auditd_space_left_disk_size: 10000
 auditd_space_left_action: syslog # Linux: RHEL default is syslog
-auditd_admin_left_disk_size: 5000
+auditd_admin_left_disk_size: 5000 # Defautl to 5GB
 auditd_admin_space_left_action: rotate # Linux: RHEL default is rotate
 auditd_action_mail_acct: root # Linux: RHEL default is root
 


### PR DESCRIPTION
Description
---

Fixing audit log conf variables to have digits (in megabytes). Auditd process started failing in AL2 since it is not supporting % values. 

```
Jan 15 12:01:38 ip-10-206-1-92 auditd: Value 50% should only be numbers - line 24
Jan 15 12:01:38 ip-10-206-1-92 auditd: The audit daemon is exiting.
```